### PR TITLE
Fix slice-rendering correctness bugs

### DIFF
--- a/tesseractinator/geometry.py
+++ b/tesseractinator/geometry.py
@@ -140,12 +140,12 @@ def project_4d_to_3d(points4d: np.ndarray, viewer_distance: float = DEFAULT_VIEW
     return points4d[:, :3] * factor[:, np.newaxis]
 
 
-def slice_tesseract(
+def _slice_tesseract_with_hull(
     angles: Mapping[str, float] | None,
     *,
     w_fixed: float = 0.0,
     tol: float = TOL,
-) -> Tuple[np.ndarray, List[Edge]]:
+) -> Tuple[np.ndarray, List[Edge], ConvexHull]:
     w_fixed = _validate_finite_number(w_fixed, "w_fixed")
     tol = _validate_finite_number(tol, "tol", positive=True)
     rotated_verts = rotate_points(generate_tesseract_vertices(), angles)
@@ -157,8 +157,6 @@ def slice_tesseract(
         w1, w2 = p1[3], p2[3]
 
         if (w1 < w_fixed and w2 > w_fixed) or (w2 < w_fixed and w1 > w_fixed):
-            if np.isclose(w1, w2, atol=tol):
-                continue
             t = (w_fixed - w1) / (w2 - w1)
             intersection = p1 + t * (p2 - p1)
             intersection_points.append(intersection[:3])
@@ -192,4 +190,14 @@ def slice_tesseract(
 
     final_vertices = hull.points
     edges = [(final_vertices[i], final_vertices[j]) for i, j in edge_set]
-    return final_vertices, edges
+    return final_vertices, edges, hull
+
+
+def slice_tesseract(
+    angles: Mapping[str, float] | None,
+    *,
+    w_fixed: float = 0.0,
+    tol: float = TOL,
+) -> Tuple[np.ndarray, List[Edge]]:
+    vertices, edges, _ = _slice_tesseract_with_hull(angles, w_fixed=w_fixed, tol=tol)
+    return vertices, edges

--- a/tesseractinator/rendering.py
+++ b/tesseractinator/rendering.py
@@ -6,16 +6,17 @@ from itertools import combinations
 from typing import Mapping
 
 import numpy as np
-from scipy.spatial import ConvexHull, QhullError
+from scipy.spatial import ConvexHull
 
 from ._constants import AXIS_COLORS, AXIS_LABELS, DEFAULT_VIEWER_DISTANCE, DEFAULT_W_SLICE, TOL
 from .geometry import (
+    SliceError,
+    _slice_tesseract_with_hull,
     generate_tesseract_edge_indices,
     generate_tesseract_vertices,
     normalize_angles,
     project_4d_to_3d,
     rotate_points,
-    slice_tesseract,
 )
 
 __all__ = ["plot_dashboard", "plot_projection", "plot_slice"]
@@ -176,13 +177,8 @@ def _render_dashboard_to_figure(figure, angles: Mapping[str, float], view_mode: 
     return figure
 
 
-def _build_slice_surface(vertices: np.ndarray, ax):
+def _build_slice_surface(vertices: np.ndarray, hull: ConvexHull, ax):
     plt, _, _, Poly3DCollection = _require_matplotlib()
-    try:
-        hull = ConvexHull(vertices, qhull_options="QJ")
-    except QhullError:
-        return None, [], np.array([], dtype=int)
-
     centroid = vertices.mean(axis=0)
     view_dir = _camera_direction(ax)
     face_normals = {}
@@ -253,23 +249,16 @@ def _build_slice_surface(vertices: np.ndarray, ax):
 def _draw_slice(ax, angles: Mapping[str, float], w_fixed: float, *, tol: float, show_info: bool) -> bool:
     _, _, Line3DCollection, _ = _require_matplotlib()
     try:
-        vertices, edges = slice_tesseract(angles, w_fixed=w_fixed, tol=tol)
-    except Exception as exc:
-        from .geometry import SliceError
-
-        if isinstance(exc, SliceError):
-            _draw_empty_slice(ax, w_fixed)
-            return False
-        raise
+        vertices, edges, hull = _slice_tesseract_with_hull(angles, w_fixed=w_fixed, tol=tol)
+    except SliceError:
+        _draw_empty_slice(ax, w_fixed)
+        return False
 
     distances = np.linalg.norm(vertices, axis=1)
     denominator = float(np.max(distances))
-    normalized = np.zeros_like(distances) if np.isclose(denominator, 0.0) else distances / denominator
-    colors = np.linspace(0.15, 0.95, len(vertices))
-    if len(vertices):
-        colors = normalized
+    colors = np.zeros_like(distances) if np.isclose(denominator, 0.0) else distances / denominator
 
-    face_collection, visible_edges, visible_vertex_indices = _build_slice_surface(vertices, ax)
+    face_collection, visible_edges, visible_vertex_indices = _build_slice_surface(vertices, hull, ax)
     if face_collection is not None:
         ax.add_collection3d(face_collection)
     edge_segments = visible_edges or edges


### PR DESCRIPTION
## Summary

Fixes the four correctness items in #1, all of which live on the `slice_tesseract` → `_draw_slice` → `_build_slice_surface` path.

- Narrowed the broad `except Exception` in `_draw_slice` to `except SliceError`. Unrelated errors (e.g., `ImportError`, `TypeError`) are no longer silently rendered as "No Slice Intersection."
- Eliminated the redundant `ConvexHull` and double QJ jitter. `geometry.py` now exposes an internal `_slice_tesseract_with_hull` that returns the hull alongside the vertices and edges; the renderer reuses it instead of computing a second hull on already-jittered points. The public `slice_tesseract(...)` API is unchanged (still returns `(vertices, edges)`).
- Removed the dead `linspace` initialization in slice color computation — it was always overwritten.
- Removed the unreachable `np.isclose(w1, w2, atol=tol)` guard inside the strict cross-hyperplane branch of `slice_tesseract`.

## Test plan

- [x] `pytest -q` passes locally (26 / 26)
- [x] Smoke test of `_slice_tesseract_with_hull`, `slice_tesseract`, and `plot_slice` empty-state path
- [ ] CI passes on push

Closes #1