### PR TITLE
Modernize CI workflow and add ruff lint/format gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,21 +4,53 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+      - name: Ruff check
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+
+  test:
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: pytest -q --cov=tesseractinator --cov-report=term --cov-report=xml
+      - name: Upload coverage artifact
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tesseractinator"
 version = "0.1.0"
 description = "Unified notebook-first tools for projecting and slicing a rotating 4D tesseract."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Michael Bagalman" }]
 dependencies = [
@@ -24,6 +24,8 @@ notebook = [
 ]
 dev = [
   "pytest>=8.0",
+  "pytest-cov>=4.0",
+  "ruff>=0.6",
 ]
 
 [tool.setuptools]
@@ -35,3 +37,21 @@ include = ["tesseractinator*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 110
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle errors
+  "F",    # pyflakes
+  "W",    # pycodestyle warnings
+  "I",    # isort
+  "UP",   # pyupgrade
+  "B",    # flake8-bugbear
+  "SIM",  # flake8-simplify
+]
+ignore = [
+  "E501",  # line length is enforced by formatter, not lint
+]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()

--- a/tesseractinator/geometry.py
+++ b/tesseractinator/geometry.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import lru_cache
 from numbers import Integral
-from typing import Dict, List, Mapping, Tuple
 
 import numpy as np
 from scipy.spatial import ConvexHull, QhullError
 
 from ._constants import DEFAULT_VIEWER_DISTANCE, EPSILON, PLANE_TO_AXES, TOL, VALID_PLANES
 
-AngleDict = Dict[str, float]
-Edge = Tuple[np.ndarray, np.ndarray]
+AngleDict = dict[str, float]
+Edge = tuple[np.ndarray, np.ndarray]
 
 __all__ = [
     "AngleDict",
@@ -145,7 +145,7 @@ def _slice_tesseract_with_hull(
     *,
     w_fixed: float = 0.0,
     tol: float = TOL,
-) -> Tuple[np.ndarray, List[Edge], ConvexHull]:
+) -> tuple[np.ndarray, list[Edge], ConvexHull]:
     w_fixed = _validate_finite_number(w_fixed, "w_fixed")
     tol = _validate_finite_number(tol, "tol", positive=True)
     rotated_verts = rotate_points(generate_tesseract_vertices(), angles)
@@ -198,6 +198,6 @@ def slice_tesseract(
     *,
     w_fixed: float = 0.0,
     tol: float = TOL,
-) -> Tuple[np.ndarray, List[Edge]]:
+) -> tuple[np.ndarray, list[Edge]]:
     vertices, edges, _ = _slice_tesseract_with_hull(angles, w_fixed=w_fixed, tol=tol)
     return vertices, edges

--- a/tesseractinator/notebook.py
+++ b/tesseractinator/notebook.py
@@ -18,7 +18,7 @@ def create_interactive_dashboard(display_ui: bool = True):
         from IPython.display import display
     except ImportError as exc:
         raise ImportError(
-            "Interactive notebooks require ipywidgets and IPython. Install with `pip install \".[notebook]\"`."
+            'Interactive notebooks require ipywidgets and IPython. Install with `pip install ".[notebook]"`.'
         ) from exc
 
     presets = standard_presets()
@@ -77,11 +77,7 @@ def create_interactive_dashboard(display_ui: bool = True):
     output = widgets.Output()
 
     def current_angles():
-        return {
-            plane: slider.value
-            for plane, slider in sliders.items()
-            if not np.isclose(slider.value, 0.0)
-        }
+        return {plane: slider.value for plane, slider in sliders.items() if not np.isclose(slider.value, 0.0)}
 
     def render(*_):
         if state["figure"] is None:
@@ -136,7 +132,9 @@ def create_interactive_dashboard(display_ui: bool = True):
     controls_right = widgets.VBox(list(sliders.values()))
     container = widgets.VBox(
         [
-            widgets.HTML("<h2>4D-Tesseractinator</h2><p>Rotate a 4D tesseract and inspect the projection, slice, or both.</p>"),
+            widgets.HTML(
+                "<h2>4D-Tesseractinator</h2><p>Rotate a 4D tesseract and inspect the projection, slice, or both.</p>"
+            ),
             widgets.HBox([controls_left, controls_right]),
             output,
         ]

--- a/tesseractinator/presets.py
+++ b/tesseractinator/presets.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
 import numpy as np
 
-AngleDict = Dict[str, float]
+AngleDict = dict[str, float]
 
 __all__ = ["standard_presets"]
 
 
-def standard_presets() -> Dict[str, AngleDict]:
+def standard_presets() -> dict[str, AngleDict]:
     return {
         "identity": {},
         "xy_45": {"xy": np.pi / 4},

--- a/tesseractinator/rendering.py
+++ b/tesseractinator/rendering.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from itertools import combinations
-from typing import Mapping
 
 import numpy as np
 from scipy.spatial import ConvexHull
@@ -42,7 +42,7 @@ def _set_equal_aspect(ax, vertices: np.ndarray) -> None:
     max_range = (vertices.max(axis=0) - vertices.min(axis=0)).max() / 2.0
     center = vertices.mean(axis=0)
     max_range = max(max_range, 0.5)
-    for setter, coord in zip((ax.set_xlim, ax.set_ylim, ax.set_zlim), center):
+    for setter, coord in zip((ax.set_xlim, ax.set_ylim, ax.set_zlim), center, strict=True):
         setter(coord - max_range, coord + max_range)
     ax.set_box_aspect((1, 1, 1))
 
@@ -53,7 +53,9 @@ def _rotation_text(angles: Mapping[str, float]) -> str:
     return ", ".join(f"{plane}={value:+.2f}" for plane, value in angles.items())
 
 
-def _draw_projection(ax, angles: Mapping[str, float], viewer_distance: float, *, add_legend: bool, add_colorbar: bool):
+def _draw_projection(
+    ax, angles: Mapping[str, float], viewer_distance: float, *, add_legend: bool, add_colorbar: bool
+):
     plt, Line2D, Line3DCollection, _ = _require_matplotlib()
     vertices4d = generate_tesseract_vertices()
     edges = generate_tesseract_edge_indices()
@@ -102,7 +104,7 @@ def _draw_projection(ax, angles: Mapping[str, float], viewer_distance: float, *,
     if add_legend:
         legend_elements = [
             Line2D([0], [0], color=color, lw=3, label=f"{label}-aligned")
-            for color, label in zip(AXIS_COLORS, AXIS_LABELS)
+            for color, label in zip(AXIS_COLORS, AXIS_LABELS, strict=True)
         ]
         ax.legend(handles=legend_elements, loc="upper right")
     if add_colorbar:
@@ -155,7 +157,9 @@ def _configure_figure(figure, view_mode: str):
     return figure.add_subplot(111, projection="3d")
 
 
-def _render_dashboard_to_figure(figure, angles: Mapping[str, float], view_mode: str, viewer_distance: float, w_fixed: float):
+def _render_dashboard_to_figure(
+    figure, angles: Mapping[str, float], view_mode: str, viewer_distance: float, w_fixed: float
+):
     figure.clear()
     if view_mode == "projection":
         axis = _configure_figure(figure, view_mode)
@@ -209,7 +213,9 @@ def _build_slice_surface(vertices: np.ndarray, hull: ConvexHull, ax):
     if not front_faces:
         return None, [], np.array([], dtype=int)
 
-    face_strength = np.array([max(0.0, np.dot(face_normals[index], view_dir)) for index in front_face_indices], dtype=float)
+    face_strength = np.array(
+        [max(0.0, np.dot(face_normals[index], view_dir)) for index in front_face_indices], dtype=float
+    )
     if np.isclose(face_strength.max(), face_strength.min()):
         color_values = np.full(len(front_faces), 0.5)
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
 
-
 os.environ.setdefault("MPLBACKEND", "Agg")
 os.environ.setdefault("MPLCONFIGDIR", str(Path(__file__).resolve().parent / ".mplconfig"))

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -10,8 +10,8 @@ matplotlib.use("Agg")
 from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
 
-from tesseractinator.geometry import slice_tesseract
 from tesseractinator import plot_dashboard, plot_projection, plot_slice
+from tesseractinator.geometry import slice_tesseract
 
 
 def test_plot_projection_returns_figure():
@@ -51,7 +51,9 @@ def test_plot_slice_hides_occluded_edges_for_default_view():
 
 def test_plot_slice_hides_back_side_vertices_for_default_view():
     figure = plot_slice({}, w_fixed=0.0)
-    scatter = next(collection for collection in figure.axes[0].collections if hasattr(collection, "_offsets3d"))
+    scatter = next(
+        collection for collection in figure.axes[0].collections if hasattr(collection, "_offsets3d")
+    )
     visible_vertex_count = len(np.asarray(scatter._offsets3d[0]))
     all_vertices, _ = slice_tesseract({}, w_fixed=0.0)
     assert 0 < visible_vertex_count < len(all_vertices)


### PR DESCRIPTION
## Summary

Addresses everything in #2:

**CI ([.github/workflows/tests.yml](.github/workflows/tests.yml))**
- Added `os` matrix: `ubuntu-latest`, `windows-latest`, `macos-latest` (was Linux-only).
- Refreshed Python matrix to `3.10`, `3.11`, `3.12`, `3.13` (dropped 3.9, added 3.13).
- Added a concurrency group keyed on workflow + ref with `cancel-in-progress: true` so PR pushes don't trigger duplicate / overlapping runs.
- Enabled pip caching via `setup-python`'s built-in `cache: pip`.
- New `lint` job runs `ruff check` and `ruff format --check`.
- `test` job now runs with `pytest --cov`; `coverage.xml` is uploaded as an artifact from the ubuntu/3.12 cell.

**Tooling ([pyproject.toml](pyproject.toml))**
- Bumped `requires-python` to `>=3.10` to align with the new CI floor.
- Added `ruff>=0.6` and `pytest-cov>=4.0` to the `dev` extra.
- Added a `[tool.ruff]` section: line-length 110, `target-version = py310`, lint selects `E/F/W/I/UP/B/SIM`.

**Codebase cleanup driven by ruff**
- Replaced `typing.Dict/List/Tuple` with built-in `dict/list/tuple` (PEP 585).
- Moved `Mapping` import from `typing` to `collections.abc`.
- Added `strict=True` to two `zip()` calls where lengths are known to match.
- Sorted imports and applied `ruff format` across affected files.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pytest -q --cov=tesseractinator` passes (26 / 26, 81% total coverage; only the notebook module is below 80% — covered by #5)
- [ ] CI passes across all 12 OS × Python cells

Closes #2