### PR TITLE
Single-source version and remove vestigial setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/tesseractinator/__init__.py
+++ b/tesseractinator/__init__.py
@@ -1,5 +1,7 @@
 """Unified tools for exploring a rotating tesseract."""
 
+from importlib.metadata import version
+
 from .geometry import (
     SliceError,
     compose_rotation_matrix,
@@ -26,4 +28,4 @@ __all__ = [
     "standard_presets",
 ]
 
-__version__ = "0.1.0"
+__version__ = version("tesseractinator")


### PR DESCRIPTION
## Summary

Both items from #3:

- Read `__version__` from package metadata via `importlib.metadata.version("tesseractinator")` instead of hardcoding it in `__init__.py`. `pyproject.toml` is now the only place the version lives, so the two can't drift.
- Delete `setup.py`. With `pyproject.toml` declaring the `setuptools.build_meta` build backend, the empty `setup()` shim is no longer needed by pip or setuptools.

## Test plan

- [x] `pip install -e ".[dev]"` succeeds with no `setup.py` present
- [x] `python -c "import tesseractinator; print(tesseractinator.__version__)"` prints `0.1.0`
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `pytest -q` passes (26 / 26)
- [ ] CI passes

Closes #3