### PR TITLE
Strengthen test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ".[dev]"
+          pip install ".[notebook,dev]"
       - name: Run tests with coverage
         run: pytest -q --cov=tesseractinator --cov-report=term --cov-report=xml
       - name: Upload coverage artifact

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -40,6 +40,32 @@ def test_compose_rotation_matrix_is_orthonormal():
     assert np.allclose(matrix.T @ matrix, np.eye(4), atol=1e-10)
 
 
+def test_rotation_matrix_4d_pins_rotation_direction():
+    # 90 degrees in the xy plane sends +x to +y.
+    R_xy = rotation_matrix_4d(0, 1, np.pi / 2)
+    assert np.allclose(R_xy @ np.array([1.0, 0.0, 0.0, 0.0]), [0.0, 1.0, 0.0, 0.0], atol=1e-12)
+    # 90 degrees in the xw plane sends +x to +w.
+    R_xw = rotation_matrix_4d(0, 3, np.pi / 2)
+    assert np.allclose(R_xw @ np.array([1.0, 0.0, 0.0, 0.0]), [0.0, 0.0, 0.0, 1.0], atol=1e-12)
+
+
+def test_compose_rotation_matrix_uses_insertion_order():
+    a, b = 0.5, 0.7
+    R_xy = rotation_matrix_4d(0, 1, a)
+    R_xw = rotation_matrix_4d(0, 3, b)
+
+    # compose pre-multiplies new rotations: {xy: a, xw: b} -> R_xw @ R_xy.
+    forward = compose_rotation_matrix({"xy": a, "xw": b})
+    assert np.allclose(forward, R_xw @ R_xy, atol=1e-12)
+
+    # Reversed insertion gives the other product.
+    reversed_ = compose_rotation_matrix({"xw": b, "xy": a})
+    assert np.allclose(reversed_, R_xy @ R_xw, atol=1e-12)
+
+    # And the two are not the same matrix (4D rotations don't commute).
+    assert not np.allclose(forward, reversed_, atol=1e-6)
+
+
 @pytest.mark.parametrize(
     "axis1, axis2",
     [
@@ -52,6 +78,26 @@ def test_compose_rotation_matrix_is_orthonormal():
 def test_rotation_matrix_rejects_invalid_axes(axis1, axis2):
     with pytest.raises(ValueError):
         rotation_matrix_4d(axis1, axis2, 0.2)
+
+
+def test_project_4d_to_3d_known_values():
+    viewer_distance = 4.0
+    points = np.array(
+        [
+            [1.0, 2.0, 3.0, 0.0],  # factor = 4 / (4 - 0) = 1
+            [1.0, 2.0, 3.0, 2.0],  # factor = 4 / (4 - 2) = 2
+            [1.0, 2.0, 3.0, -4.0],  # factor = 4 / (4 - -4) = 0.5
+        ]
+    )
+    expected = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [2.0, 4.0, 6.0],
+            [0.5, 1.0, 1.5],
+        ]
+    )
+    actual = project_4d_to_3d(points, viewer_distance=viewer_distance)
+    assert np.allclose(actual, expected, atol=1e-12)
 
 
 def test_project_4d_to_3d_preserves_sign_near_projection_plane():

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,0 +1,19 @@
+import os
+
+import matplotlib
+import pytest
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+matplotlib.use("Agg")
+
+pytest.importorskip("ipywidgets")
+pytest.importorskip("IPython")
+
+import ipywidgets as widgets
+
+from tesseractinator.notebook import create_interactive_dashboard
+
+
+def test_create_interactive_dashboard_smoke():
+    container = create_interactive_dashboard(display_ui=False)
+    assert isinstance(container, widgets.VBox)


### PR DESCRIPTION
## Summary

Adds four targeted tests addressing every gap in #5.

**Pin rotation direction** — `test_rotation_matrix_4d_pins_rotation_direction`
pins which way positive rotation goes: 90° in `xy` sends `+x → +y`, and 90° in `xw` sends `+x → +w`. Catches sign / axis-swap regressions that the orthonormality tests would miss.

**Pin composition order** — `test_compose_rotation_matrix_uses_insertion_order`
asserts that `compose_rotation_matrix({"xy": a, "xw": b})` equals `R_xw @ R_xy` (and the reverse insertion gives `R_xy @ R_xw`). Catches a silent flip in composition direction; the existing `test_rotation_order_is_respected` would pass even if both directions were reversed identically.

**Pin projection numerics** — `test_project_4d_to_3d_known_values` pins the perspective formula at three `w` values (`0`, `2`, `-4`) with `viewer_distance=4`, asserting the exact projected coordinates.

**Notebook smoke test** — new [tests/test_notebook.py](tests/test_notebook.py) builds the dashboard widget via `create_interactive_dashboard(display_ui=False)` and asserts a `VBox` comes back. CI workflow now installs `[notebook,dev]` so this runs in CI; locally it self-skips if `ipywidgets` isn't installed.

## Coverage impact

| Module | Before | After |
| --- | --- | --- |
| `tesseractinator/notebook.py` | 10% | **81%** |
| **Total** | **81%** | **92%** |

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pytest -q` passes (30 / 30, was 26 / 26)
- [x] Coverage rises from 81% → 92% (notebook 10% → 81%)
- [ ] CI passes across all 12 OS × Python cells

Closes #5