### PR TITLE
Bump GitHub Actions to Node.js 24-compatible majors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -37,8 +37,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -51,7 +51,7 @@ jobs:
         run: pytest -q --cov=tesseractinator --cov-report=term --cov-report=xml
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-xml
           path: coverage.xml


### PR DESCRIPTION
## Summary

Resolves #9. GitHub will force all Actions to Node.js 24 starting **June 2nd, 2026**, and Node.js 20 will be removed from runners on **September 16th, 2026**. CI was emitting Node 20 deprecation warnings on every run.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |

All three majors are Node.js 24 compatible.

## Test plan

- [ ] CI passes across all 13 jobs (lint + 12 OS × Python cells)
- [ ] No Node.js 20 deprecation warnings in run logs

Closes #9