### PR TITLE
Ignore Claude Code per-project settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dist/
 pip-wheel-metadata/
 .idea/
 .vscode/
+.claude/


### PR DESCRIPTION
## Summary

Add `.claude/` to `.gitignore` so per-project Claude Code settings (`settings.local.json`, etc.) don't accidentally get staged. Sits next to the existing `.idea/` and `.vscode/` editor-state entries.

## Test plan

- [x] `git status` no longer lists `.claude/` as untracked
- [ ] CI passes (no code changed; expected to pass trivially)